### PR TITLE
Updated code to use hmac's compare_disgest instead werkzeug's safe_str_cmp

### DIFF
--- a/section01/05_our_project_and_endpoints/start/resources/user.py
+++ b/section01/05_our_project_and_endpoints/start/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/06_reviewing_beginner_course_code/start/resources/user.py
+++ b/section01/06_reviewing_beginner_course_code/start/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/07_simplifying_error_handling/end/resources/user.py
+++ b/section01/07_simplifying_error_handling/end/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/07_simplifying_error_handling/start/resources/user.py
+++ b/section01/07_simplifying_error_handling/start/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/08_refactoring_resources/end/resources/user.py
+++ b/section01/08_refactoring_resources/end/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/08_refactoring_resources/start/resources/user.py
+++ b/section01/08_refactoring_resources/start/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/09_should_have_unique_names/end/resources/user.py
+++ b/section01/09_should_have_unique_names/end/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/09_should_have_unique_names/start/resources/user.py
+++ b/section01/09_should_have_unique_names/start/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/10_adding_basic_type_hinting/end/resources/user.py
+++ b/section01/10_adding_basic_type_hinting/end/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/10_adding_basic_type_hinting/start/resources/user.py
+++ b/section01/10_adding_basic_type_hinting/start/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/11_adding_custom_json_types/end/resources/user.py
+++ b/section01/11_adding_custom_json_types/end/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/11_adding_custom_json_types/start/resources/user.py
+++ b/section01/11_adding_custom_json_types/start/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/12_using_current_class_as_type_hint/end/resources/user.py
+++ b/section01/12_using_current_class_as_type_hint/end/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/12_using_current_class_as_type_hint/start/resources/user.py
+++ b/section01/12_using_current_class_as_type_hint/start/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/13_using_black_code_formatting/end/resources/user.py
+++ b/section01/13_using_black_code_formatting/end/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/13_using_black_code_formatting/start/resources/user.py
+++ b/section01/13_using_black_code_formatting/start/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/14_improving_errors_with_constants/end/resources/user.py
+++ b/section01/14_improving_errors_with_constants/end/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -69,7 +69,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/14_improving_errors_with_constants/start/resources/user.py
+++ b/section01/14_improving_errors_with_constants/start/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -61,7 +61,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/15_classmethod_across_the_board/end/resources/user.py
+++ b/section01/15_classmethod_across_the_board/end/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -71,7 +71,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section01/15_classmethod_across_the_board/start/resources/user.py
+++ b/section01/15_classmethod_across_the_board/start/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -69,7 +69,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section02/21_migrating_virtualenv_pipenv/end/resources/user.py
+++ b/section02/21_migrating_virtualenv_pipenv/end/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -71,7 +71,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section02/21_migrating_virtualenv_pipenv/start/resources/user.py
+++ b/section02/21_migrating_virtualenv_pipenv/start/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -71,7 +71,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section02/23_vanilla_marshmallow/end/resources/user.py
+++ b/section02/23_vanilla_marshmallow/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -70,7 +70,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data["username"])
 
-        if user and safe_str_cmp(user_data["password"], user.password):
+        if user and compare_digest(user_data["password"], user.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section02/23_vanilla_marshmallow/start/resources/user.py
+++ b/section02/23_vanilla_marshmallow/start/resources/user.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource, reqparse
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -71,7 +71,7 @@ class UserLogin(Resource):
         user = UserModel.find_by_username(data["username"])
 
         # this is what the `authenticate()` function did in security.py
-        if user and safe_str_cmp(user.password, data["password"]):
+        if user and compare_digest(user.password, data["password"]):
             # identity= is what the identity() function did in security.py—now stored in the JWT
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)

--- a/section02/25_flask_marshmallow/end/resources/user.py
+++ b/section02/25_flask_marshmallow/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -69,7 +69,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section02/25_flask_marshmallow/start/resources/user.py
+++ b/section02/25_flask_marshmallow/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -70,7 +70,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data["username"])
 
-        if user and safe_str_cmp(user_data["password"], user.password):
+        if user and compare_digest(user_data["password"], user.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section02/26_adding_items_to_rest_api/end/resources/user.py
+++ b/section02/26_adding_items_to_rest_api/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -69,7 +69,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section02/26_adding_items_to_rest_api/start/resources/user.py
+++ b/section02/26_adding_items_to_rest_api/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -69,7 +69,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section02/27_adding_stores_to_rest_api/end/resources/user.py
+++ b/section02/27_adding_stores_to_rest_api/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -69,7 +69,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section02/27_adding_stores_to_rest_api/start/resources/user.py
+++ b/section02/27_adding_stores_to_rest_api/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -69,7 +69,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section02/28_deduplicating_error_handling/end/resources/user.py
+++ b/section02/28_deduplicating_error_handling/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -63,7 +63,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section02/28_deduplicating_error_handling/start/resources/user.py
+++ b/section02/28_deduplicating_error_handling/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -69,7 +69,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section03/33_adding_activated_prop/end/resources/user.py
+++ b/section03/33_adding_activated_prop/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -66,7 +66,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section03/33_adding_activated_prop/start/resources/user.py
+++ b/section03/33_adding_activated_prop/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -63,7 +63,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section03/34_activating_users_manually/end/resources/user.py
+++ b/section03/34_activating_users_manually/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -67,7 +67,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section03/34_activating_users_manually/start/resources/user.py
+++ b/section03/34_activating_users_manually/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -66,7 +66,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section03/35_telling_users_they_are_active/end/resources/user.py
+++ b/section03/35_telling_users_they_are_active/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -66,7 +66,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section03/35_telling_users_they_are_active/start/resources/user.py
+++ b/section03/35_telling_users_they_are_active/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -67,7 +67,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section03/37_send_emails_mailgun_part1/end/resources/user.py
+++ b/section03/37_send_emails_mailgun_part1/end/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -76,7 +76,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section03/37_send_emails_mailgun_part1/start/resources/user.py
+++ b/section03/37_send_emails_mailgun_part1/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -66,7 +66,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section03/39_creating_mailgun_lib_file/end/resources/user.py
+++ b/section03/39_creating_mailgun_lib_file/end/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -76,7 +76,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section03/39_creating_mailgun_lib_file/start/resources/user.py
+++ b/section03/39_creating_mailgun_lib_file/start/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -76,7 +76,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section03/40_using_env_files_flask/end/resources/user.py
+++ b/section03/40_using_env_files_flask/end/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -76,7 +76,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section03/40_using_env_files_flask/start/resources/user.py
+++ b/section03/40_using_env_files_flask/start/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -76,7 +76,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section03/41_adding_configuration_to_dotenv/end/resources/user.py
+++ b/section03/41_adding_configuration_to_dotenv/end/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -76,7 +76,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section03/41_adding_configuration_to_dotenv/start/resources/user.py
+++ b/section03/41_adding_configuration_to_dotenv/start/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -76,7 +76,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section03/42_error_handling_mailgun/end/resources/user.py
+++ b/section03/42_error_handling_mailgun/end/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -80,7 +80,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section03/42_error_handling_mailgun/start/resources/user.py
+++ b/section03/42_error_handling_mailgun/start/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -76,7 +76,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section04/46_creating_confirmation_model/end/resources/user.py
+++ b/section04/46_creating_confirmation_model/end/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -80,7 +80,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section04/46_creating_confirmation_model/start/resources/user.py
+++ b/section04/46_creating_confirmation_model/start/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -80,7 +80,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section04/47_changes_in_usermodel/end/resources/user.py
+++ b/section04/47_changes_in_usermodel/end/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -80,7 +80,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section04/47_changes_in_usermodel/start/resources/user.py
+++ b/section04/47_changes_in_usermodel/start/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -80,7 +80,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section04/48_creating_confirmationresource/end/resources/user.py
+++ b/section04/48_creating_confirmationresource/end/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -80,7 +80,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section04/48_creating_confirmationresource/start/resources/user.py
+++ b/section04/48_creating_confirmationresource/start/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -80,7 +80,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section04/49_updating_userresource/end/resources/user.py
+++ b/section04/49_updating_userresource/end/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -85,7 +85,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(identity=user.id, fresh=True)

--- a/section04/49_updating_userresource/start/resources/user.py
+++ b/section04/49_updating_userresource/start/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request, render_template, make_response
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -80,7 +80,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             if user.activated:
                 access_token = create_access_token(identity=user.id, fresh=True)
                 refresh_token = create_refresh_token(user.id)

--- a/section04/51_adding_last_confirmation_to_user_schema/end/resources/user.py
+++ b/section04/51_adding_last_confirmation_to_user_schema/end/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -85,7 +85,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(identity=user.id, fresh=True)

--- a/section04/51_adding_last_confirmation_to_user_schema/start/resources/user.py
+++ b/section04/51_adding_last_confirmation_to_user_schema/start/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -85,7 +85,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(identity=user.id, fresh=True)

--- a/section04/52_fixing_app_py/end/resources/user.py
+++ b/section04/52_fixing_app_py/end/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -85,7 +85,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(identity=user.id, fresh=True)

--- a/section04/52_fixing_app_py/start/resources/user.py
+++ b/section04/52_fixing_app_py/start/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -85,7 +85,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(identity=user.id, fresh=True)

--- a/section04/55_storing_strings_in_config_files/end/resources/user.py
+++ b/section04/55_storing_strings_in_config_files/end/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -85,7 +85,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(identity=user.id, fresh=True)

--- a/section04/55_storing_strings_in_config_files/start/resources/user.py
+++ b/section04/55_storing_strings_in_config_files/start/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -85,7 +85,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(identity=user.id, fresh=True)

--- a/section04/56_creating_simple_translation_lib/end/resources/user.py
+++ b/section04/56_creating_simple_translation_lib/end/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -85,7 +85,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(identity=user.id, fresh=True)

--- a/section04/56_creating_simple_translation_lib/start/resources/user.py
+++ b/section04/56_creating_simple_translation_lib/start/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -85,7 +85,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(identity=user.id, fresh=True)

--- a/section04/57_updating_resources_to_use_translations/end/resources/user.py
+++ b/section04/57_updating_resources_to_use_translations/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section04/57_updating_resources_to_use_translations/start/resources/user.py
+++ b/section04/57_updating_resources_to_use_translations/start/resources/user.py
@@ -1,7 +1,7 @@
 import traceback
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -85,7 +85,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user_data.password, user.password):
+        if user and compare_digest(user_data.password, user.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(identity=user.id, fresh=True)

--- a/section04/58_adding_new_language/end/resources/user.py
+++ b/section04/58_adding_new_language/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section04/58_adding_new_language/start/resources/user.py
+++ b/section04/58_adding_new_language/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/75_install_flask_uploads/end/resources/user.py
+++ b/section06/75_install_flask_uploads/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/75_install_flask_uploads/start/resources/user.py
+++ b/section06/75_install_flask_uploads/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/76_config_files_flask/end/resources/user.py
+++ b/section06/76_config_files_flask/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/76_config_files_flask/start/resources/user.py
+++ b/section06/76_config_files_flask/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/78_creating_image_helper_lib/end/resources/user.py
+++ b/section06/78_creating_image_helper_lib/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/78_creating_image_helper_lib/start/resources/user.py
+++ b/section06/78_creating_image_helper_lib/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/79_creating_image_schema/end/resources/user.py
+++ b/section06/79_creating_image_schema/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/79_creating_image_schema/start/resources/user.py
+++ b/section06/79_creating_image_schema/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/80_creating_image_upload_resource/end/resources/user.py
+++ b/section06/80_creating_image_upload_resource/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/80_creating_image_upload_resource/start/resources/user.py
+++ b/section06/80_creating_image_upload_resource/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/81_trying_image_upload/end/resources/user.py
+++ b/section06/81_trying_image_upload/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/81_trying_image_upload/start/resources/user.py
+++ b/section06/81_trying_image_upload/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/82_retrieving_and_deleting_images/end/resources/user.py
+++ b/section06/82_retrieving_and_deleting_images/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/82_retrieving_and_deleting_images/start/resources/user.py
+++ b/section06/82_retrieving_and_deleting_images/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/83_another_example_user_avatars/end/resources/user.py
+++ b/section06/83_another_example_user_avatars/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/83_another_example_user_avatars/start/resources/user.py
+++ b/section06/83_another_example_user_avatars/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/84_adding_avatar_resource/end/resources/user.py
+++ b/section06/84_adding_avatar_resource/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section06/84_adding_avatar_resource/start/resources/user.py
+++ b/section06/84_adding_avatar_resource/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -79,7 +79,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             confirmation = user.most_recent_confirmation
             if confirmation and confirmation.confirmed:
                 access_token = create_access_token(user.id, fresh=True)

--- a/section07/88_whats_in_starter_code/start/resources/user.py
+++ b/section07/88_whats_in_starter_code/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section07/90_connecting_remote_database/end/resources/user.py
+++ b/section07/90_connecting_remote_database/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section07/90_connecting_remote_database/start/resources/user.py
+++ b/section07/90_connecting_remote_database/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section07/91_initialising_flask_migrate_alembic/end/resources/user.py
+++ b/section07/91_initialising_flask_migrate_alembic/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section07/91_initialising_flask_migrate_alembic/start/resources/user.py
+++ b/section07/91_initialising_flask_migrate_alembic/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section07/94_checking_alembic_script/end/resources/user.py
+++ b/section07/94_checking_alembic_script/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section07/94_checking_alembic_script/start/resources/user.py
+++ b/section07/94_checking_alembic_script/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section07/95_adding_new_column_with_migrations/end/resources/user.py
+++ b/section07/95_adding_new_column_with_migrations/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section07/95_adding_new_column_with_migrations/start/resources/user.py
+++ b/section07/95_adding_new_column_with_migrations/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section07/98_defining_sqlalchemy_naming_convention/end/resources/user.py
+++ b/section07/98_defining_sqlalchemy_naming_convention/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section07/98_defining_sqlalchemy_naming_convention/start/resources/user.py
+++ b/section07/98_defining_sqlalchemy_naming_convention/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/103_whats_in_starter_code/start/resources/user.py
+++ b/section08/103_whats_in_starter_code/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/105_creating_github_oauth_app/end/resources/user.py
+++ b/section08/105_creating_github_oauth_app/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/105_creating_github_oauth_app/start/resources/user.py
+++ b/section08/105_creating_github_oauth_app/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/106_flask_oauthlib/end/resources/user.py
+++ b/section08/106_flask_oauthlib/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/106_flask_oauthlib/start/resources/user.py
+++ b/section08/106_flask_oauthlib/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/107_setting_up_github_client/end/resources/user.py
+++ b/section08/107_setting_up_github_client/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/107_setting_up_github_client/start/resources/user.py
+++ b/section08/107_setting_up_github_client/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/108_our_githublogin_resource/end/resources/user.py
+++ b/section08/108_our_githublogin_resource/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/108_our_githublogin_resource/start/resources/user.py
+++ b/section08/108_our_githublogin_resource/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/110_what_is_tokengetter/end/resources/user.py
+++ b/section08/110_what_is_tokengetter/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/110_what_is_tokengetter/start/resources/user.py
+++ b/section08/110_what_is_tokengetter/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/111_finishing_githubauthorize_resource/end/resources/user.py
+++ b/section08/111_finishing_githubauthorize_resource/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/111_finishing_githubauthorize_resource/start/resources/user.py
+++ b/section08/111_finishing_githubauthorize_resource/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/112_adding_error_handling/end/resources/user.py
+++ b/section08/112_adding_error_handling/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/112_adding_error_handling/start/resources/user.py
+++ b/section08/112_adding_error_handling/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/113_setting_user_passwords/end/resources/user.py
+++ b/section08/113_setting_user_passwords/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and user.password and safe_str_cmp(user.password, user_data.password):
+        if user and user.password and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/113_setting_user_passwords/start/resources/user.py
+++ b/section08/113_setting_user_passwords/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/114_using_url_for_with_flask_restful/end/resources/user.py
+++ b/section08/114_using_url_for_with_flask_restful/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and user.password and safe_str_cmp(user.password, user_data.password):
+        if user and user.password and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section08/114_using_url_for_with_flask_restful/start/resources/user.py
+++ b/section08/114_using_url_for_with_flask_restful/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -58,7 +58,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and user.password and safe_str_cmp(user.password, user_data.password):
+        if user and user.password and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/118_whats_in_starter_code/start/resources/user.py
+++ b/section09/118_whats_in_starter_code/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/121_after_payment_receive_order_data/end/resources/user.py
+++ b/section09/121_after_payment_receive_order_data/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/121_after_payment_receive_order_data/start/resources/user.py
+++ b/section09/121_after_payment_receive_order_data/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/122_creating_ordermodel/end/resources/user.py
+++ b/section09/122_creating_ordermodel/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/122_creating_ordermodel/start/resources/user.py
+++ b/section09/122_creating_ordermodel/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/123_many_to_many_relationships_sqlalchemy/end/resources/user.py
+++ b/section09/123_many_to_many_relationships_sqlalchemy/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/123_many_to_many_relationships_sqlalchemy/start/resources/user.py
+++ b/section09/123_many_to_many_relationships_sqlalchemy/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/124_using_association_object_in_resource/end/resources/user.py
+++ b/section09/124_using_association_object_in_resource/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/124_using_association_object_in_resource/start/resources/user.py
+++ b/section09/124_using_association_object_in_resource/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/125_charging_orders_with_stripe/end/resources/user.py
+++ b/section09/125_charging_orders_with_stripe/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/125_charging_orders_with_stripe/start/resources/user.py
+++ b/section09/125_charging_orders_with_stripe/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/126_calculating_amount_and_description/end/resources/user.py
+++ b/section09/126_calculating_amount_and_description/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/126_calculating_amount_and_description/start/resources/user.py
+++ b/section09/126_calculating_amount_and_description/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/128_creating_a_way_to_view_existing_orders/end/resources/user.py
+++ b/section09/128_creating_a_way_to_view_existing_orders/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/128_creating_a_way_to_view_existing_orders/start/resources/user.py
+++ b/section09/128_creating_a_way_to_view_existing_orders/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/129_error_handling_stripe/end/resources/user.py
+++ b/section09/129_error_handling_stripe/end/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/section09/129_error_handling_stripe/start/resources/user.py
+++ b/section09/129_error_handling_stripe/start/resources/user.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource
 from flask import request
-from werkzeug.security import safe_str_cmp
+from hmac import compare_digest
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -62,7 +62,7 @@ class UserLogin(Resource):
 
         user = UserModel.find_by_username(user_data.username)
 
-        if user and safe_str_cmp(user.password, user_data.password):
+        if user and compare_digest(user.password, user_data.password):
             access_token = create_access_token(identity=user.id, fresh=True)
             refresh_token = create_refresh_token(user.id)
             return {"access_token": access_token, "refresh_token": refresh_token}, 200


### PR DESCRIPTION
`safe_str_cmp` has been removed from the `werkzeug` package:

- https://werkzeug.palletsprojects.com/en/2.1.x/changes/
- https://github.com/pallets/werkzeug/pull/2276

The recommendation is to use `hmac.compare_digest` instead.

This PR changes all the lecture codes to use `hmac.compare_digest` instead of `werkzeug.safe_str_cmp`.